### PR TITLE
Recording stabilizations

### DIFF
--- a/config/systemd/jackd@raar.service.d/override.conf
+++ b/config/systemd/jackd@raar.service.d/override.conf
@@ -7,4 +7,4 @@ Group=rotter
 SupplementaryGroups=audio
 
 # Jackd startup options
-Environment="JACKD_OPTIONS=-d alsa --device hw:0 --capture --inchannels 2"
+Environment="JACKD_OPTIONS=-d alsa --device hw:0 --capture --inchannels 2 --period 2048"

--- a/config/systemd/rotter@raar.service.d/override.conf
+++ b/config/systemd/rotter@raar.service.d/override.conf
@@ -1,3 +1,3 @@
 [Service]
 # Rotter startup options
-Environment="ROTTER_OPTIONS=-a -f flac -c 2 -L '%%FT%%H%%M%%S%%z_060.flac' -j"
+Environment="ROTTER_OPTIONS=-a -f flac -c 2 -R 10 -L '%%FT%%H%%M%%S%%z_060.flac' -j"


### PR DESCRIPTION
The following PR tries to address recently observed recording issues, by increasing buffers on jackd and rotter. While this leads to higher latency, the recording should be more stable on busy or low-end systems.