### PR TITLE
fix - prevent premature recording movements

### DIFF
--- a/bin/raar-record-handler.sh
+++ b/bin/raar-record-handler.sh
@@ -69,7 +69,7 @@ echo "Watching for new records in ${watchDir}"
 echo "Recordings will be moved to ${destDir}"
 
 # The minimum size a recording must have to trigger an archival
-minFileSize="1048576" # 1 MiB
+minFileSize="$(( 20 * 1048576 ))" # 20 MiB
 
 inotifywait --monitor --event close_write "${watchDir}" | while read \
     watchedFileName eventNames eventFileName


### PR DESCRIPTION
Increase the minimum recording file size to prevent sporadic, premature recording movements.