### PR TITLE
Feature - Automatically clean-up failed rotter recordings

### DIFF
--- a/config/systemd/tmpfiles.d/rotter-raar.conf
+++ b/config/systemd/tmpfiles.d/rotter-raar.conf
@@ -1,0 +1,9 @@
+# This file is part of RAAR
+# https://github.com/radiorabe/raar/blob/master/doc/recording.md
+#
+# See tmpfiles.d(5) for details
+
+# Clean-up failed recordings after 30 days.
+#
+#Type Path                  Mode UID    GID    Age Argument
+d     /var/lib/rotter/raar  0755 rotter rotter 30d -

--- a/doc/recording.md
+++ b/doc/recording.md
@@ -261,6 +261,10 @@ chmod 755 /usr/local/bin/raar-record-handler.sh
 
 wget -O /etc/systemd/system/raar-record-handler.service \
      https://raw.githubusercontent.com/radiorabe/raar/master/config/systemd/raar-record-handler.service
+
+
+wget -O /etc/tmpfiles.d/rotter-raar.conf \
+     https://raw.githubusercontent.com/radiorabe/raar/master/config/systemd/tmpfiles.d/rotter-raar.conf
 ```
 
 You might want to adapt the destination directory, which defaults to

--- a/doc/recording.md
+++ b/doc/recording.md
@@ -260,7 +260,7 @@ chmod 755 /usr/local/bin/raar-record-handler.sh
 
 
 wget -O /etc/systemd/system/raar-record-handler.service \
-     https://raw.githubusercontent.com/paraenggu/raar/feature/recording/config/systemd/raar-record-handler.service
+     https://raw.githubusercontent.com/radiorabe/raar/master/config/systemd/raar-record-handler.service
 ```
 
 You might want to adapt the destination directory, which defaults to


### PR DESCRIPTION
This PR adds a systemd [tmpfiles.d ](https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html) configuration which ensures that the required temporary Rotter RAAR recording directory exists and that failed recordings will be deleted after 30 days.