### PR TITLE
Feature - RAAR record handler - Add effective recording duration

### DIFF
--- a/bin/raar-record-handler.sh
+++ b/bin/raar-record-handler.sh
@@ -32,6 +32,8 @@
 # watch directory, containing recording files. The script assumes, that a
 # recording has finished on such an event and moves the file to the given
 # destination directory.
+# Before moving the recording file to its final location, the script determines
+# the duration of the recording and adds it to the final file name.
 # If the archival was successful, the script sends the last successful
 # recording timestamp to a Zabbix monitoring system with the help of the
 # zabbix_sender tool.

--- a/bin/raar-record-handler.sh
+++ b/bin/raar-record-handler.sh
@@ -74,7 +74,7 @@ minFileSize="$(( 20 * 1048576 ))" # 20 MiB
 inotifywait --monitor --event close_write "${watchDir}" | while read \
     watchedFileName eventNames eventFileName
 do
-    echo "${eventNames} occoured on ${eventFileName}"
+    echo "${eventNames} occurred on ${eventFileName}"
 
     sourcePath="${watchDir}/${eventFileName}"
 
@@ -107,7 +107,7 @@ do
 
     echo "${eventFileName} successfully archived"
 
-    # Inform the monitoring system about the last successfull recording
+    # Inform the monitoring system about the last successful recording
     zabbix_sender --config /etc/zabbix/zabbix_agentd.conf \
                   --key 'rabe.raar.recording.success[]' \
                   --value "$(date +%s)" > /dev/null

--- a/bin/raar-record-handler.sh
+++ b/bin/raar-record-handler.sh
@@ -3,9 +3,9 @@
 # raar-record-handler.sh - Moves new recordings to the raar import directory
 ################################################################################
 #
-# Copyright (C) 2018 Radio Bern RaBe
-#                    Switzerland
-#                    http://www.rabe.ch
+# Copyright (C) 2018 - 2019 Radio Bern RaBe
+#                           Switzerland
+#                           https://rabe.ch
 #
 # This program is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public 

--- a/bin/raar-record-handler.sh
+++ b/bin/raar-record-handler.sh
@@ -44,6 +44,20 @@
 # raar-record-handler.sh <WATCH-DIRECTORY> <DESTINATION-DIRECTORY>
 #
 
+# Check if all required external commands are available
+for cmd in ffprobe \
+           inotifywait \
+           mv \
+           printf \
+           zabbix_sender
+do
+    command -v "${cmd}" >/dev/null 2>&1 || {
+        echo >&2 "Missing command '${cmd}'"
+        exit 1
+    }
+
+done
+
 watchDir="$1"
 destDir="$2"
 

--- a/config/systemd/rotter@raar.service.d/override.conf
+++ b/config/systemd/rotter@raar.service.d/override.conf
@@ -1,3 +1,3 @@
 [Service]
 # Rotter startup options
-Environment="ROTTER_OPTIONS=-a -f flac -c 2 -R 10 -L '%%FT%%H%%M%%S%%z_060.flac' -j"
+Environment="ROTTER_OPTIONS=-a -f flac -c 2 -R 10 -L '%%FT%%H%%M%%S%%z.flac' -j"


### PR DESCRIPTION
The following PR enhances the RAAR record handler script, so that it adds the effective recording duration to the final file name.

Previously, `rotter` was configured [to add a fixed duration of 60 minutes to every file name](https://github.com/radiorabe/raar/blob/6206ff03f4c52582239b6113926774e4ff427a6a/config/systemd/rotter%40raar.service.d/override.conf#L3) (`%%FT%%H%%M%%S%%z_060.flac`), regardless of the actual track duration.

`rotter` creates a new recording file at the start of the new hour. During the initial start or in case a recording fails, the recording file won't have a duration of 60 minutes. This PR addresses these edge-cases and ensures that the effective recording duration will be added to the final file name.

`rotter` will now be started without a fixed duration encoded into the file name. The record handler will then determine the recording duration with the help of [`ffprobe`](http://www.ffmpeg.org/ffprobe.html) and add it to the recording file name in the [ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations) in seconds.

For example, a one hour (3600 seconds) rotter recording file
`/var/lib/rotter/raar/2019-11-30T170000+0100.flac` will be renamed and moved to `/var/tmp/raar/import/2019-11-30T170000+0100_PT3600S.flac` waiting for the RAAR importer to pick it up.

This addresses #6 