### PR TITLE
chore(ci): configure dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(ci): "
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a simple dependabot config for the github-actions ecosystem.

* the actions updates get grouped into pull requests instead of creating single pull requests
* we use a `chore(ci): ` prefix because actions ususally don't need to trigger releases
* there is a cooldown of 7 days, this get more eyes on action updates before we merge them, security advisories can skip the cooldown

I can also add other ecosystems if we see value in them. I'll probably roll this out to the other raar-* repos first tho.